### PR TITLE
feat: support trpc11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,12 @@
         "vitest": "^0.34.6"
       },
       "peerDependencies": {
-        "@trpc/server": "^10.0.0"
+        "@trpc/server": "next"
+      },
+      "peerDependenciesMeta": {
+        "@trpc/server": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1181,12 +1186,13 @@
       "dev": true
     },
     "node_modules/@trpc/server": {
-      "version": "10.40.0",
-      "resolved": "https://registry.npmjs.org/@trpc/server/-/server-10.40.0.tgz",
-      "integrity": "sha512-49SUOMWzSZtu5+OdrADmJD+u+sjSE0qj1cWgYk2FY4jLkPJunLuNRuhzM7aOeBhiUjyfhg2YTfur8FN1WBmvEw==",
+      "version": "11.0.0-next-beta.221",
+      "resolved": "https://registry.npmjs.org/@trpc/server/-/server-11.0.0-next-beta.221.tgz",
+      "integrity": "sha512-mgTUHGCuYZ3BtF8VlQmeHixKLExcUcElvKNPS2tyhfBZxua36+5mPD2wZ71rMqqwN7NI0FoP1fMjFL/9VVqfEw==",
       "funding": [
         "https://trpc.io/sponsor"
       ],
+      "optional": true,
       "peer": true
     },
     "node_modules/@types/chai": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,12 @@
   },
   "homepage": "https://github.com/baselime/node-opentelemetry#readme",
   "peerDependencies": {
-    "@trpc/server": "^10.0.0"
+    "@trpc/server": "next"
+  },
+  "peerDependenciesMeta": {
+    "@trpc/server": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@opentelemetry/api": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "homepage": "https://github.com/baselime/node-opentelemetry#readme",
   "peerDependencies": {
-    "@trpc/server": "next"
+    "@trpc/server": "^10.0.0 || ^11.0.0"
   },
   "peerDependenciesMeta": {
     "@trpc/server": {

--- a/src/trpc.ts
+++ b/src/trpc.ts
@@ -23,8 +23,11 @@ export function tracing(options?: TracingOptions) {
         return tracer.startActiveSpan(`TRPC ${opts.type}`, async (span: Span) => {
             const result = await opts.next();
 
-            if (options.collectInput && typeof opts.rawInput === "object") {
-                span.setAttributes(flatten({ input: opts.rawInput }))
+            // opts.rawInput is for v10, `opts.getRawInput` is for v11
+            const rawInput =
+                "rawInput" in opts ? opts.rawInput : await opts.getRawInput();
+            if (options.collectInput && typeof rawInput === "object") {
+                span.setAttributes(flatten({ input: rawInput }))
             }
             const meta = { path: opts.path, type: opts.type, ok: result.ok };
             span.setAttributes(meta)


### PR DESCRIPTION
adds support for trpc 11 in the middleware

`experimental_standaloneMiddleware` is deprecated in favor of `experimental_trpcMiddleware` (we smurfed a lot of exports for v11) but will still be around, so I kept this change to be backwards compatible and work with both v10 and v11.

The only change relevant here is that we have turned the `rawInput` into an async getter `getRawInput` to be able to support more content types than json in the future. Ref: https://trpc.io/docs/migrate-from-v10-to-v11#rawinput-in-middleware-is-now-a-getrawinput